### PR TITLE
Fixed /jailmenu not showing for QB-Core servers

### DIFF
--- a/bridge/qb/client.lua
+++ b/bridge/qb/client.lua
@@ -13,7 +13,7 @@ end
 function GetPlayersInArea(coords, radius)
     local coords = coords or GetEntityCoords(PlayerPedId())
     local radius = radius or 3.0
-    local list = ESX.Game.GetPlayersFromCoords(coords, radius)
+    local list = QBCore.Functions.GetPlayersFromCoords(coords, radius)
     local players = {}
     for _, player in pairs(list) do 
         if player ~= PlayerId() then


### PR DESCRIPTION
Fixed issue with QB-Core Bridge where the nearby player list was looking for a ESX variable and  not a QB-Core Variable