### PR TITLE
Added Job Name + Fixed weapon spelling

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -570,7 +570,7 @@ Config.Prisons = {
                 model = {hash = `s_m_y_prisoner_01`},
                 catalog = {
                     {
-                        name = "WEAPON_SWITCHBLADE",
+                        name = "weapon_switchblade",
                         description = "A great tool to take out your enemies.",
                         amount = 1,
                         required = {

--- a/config.lua
+++ b/config.lua
@@ -27,6 +27,8 @@ Config.EnableSneakout = false -- When set to true, anytime the player is outside
 
 Config.XPEnabled = true -- When set to true, this will enable Pickle's XP compatibility, and enable xp rewards.
 
+Config.Job = 'prisoner'
+
 Config.XPCategories = { -- Registered XP Types for Pickle's XP.
     ["strength"] = {
         label = "Strength", 


### PR DESCRIPTION
Added a Prisoner job name to remove the jailed player's job upon being jailed can be set to nil if they don't want the job to be removed or set to whichever job name they would like also fixed the weapon_switchblade spelling to all llower case 