### PR TITLE
Update server.lua

### DIFF
--- a/modules/prison/server.lua
+++ b/modules/prison/server.lua
@@ -91,6 +91,7 @@ function JailPlayer(source, time, index, noSave)
     TriggerClientEvent("pickle_prisons:jailPlayer", source, Prisoners[source])
     if noSave then return end
     MySQL.Async.execute("DELETE FROM pickle_prisons WHERE identifier=@identifier;", {["@identifier"] = identifier})
+    Wait(150)
     MySQL.Async.execute("INSERT INTO pickle_prisons (identifier, prison, time, inventory, sentence_date) VALUES (@identifier, @prison, @time, @inventory, @sentence_date);", {
         ["@identifier"] = Prisoners[source].identifier,
         ["@prison"] = Prisoners[source].index,


### PR DESCRIPTION
tested on 100+ players right now, without wait it wont insert in SQL, event better idea would be to put unique key on identifier and use `ON DUPLICATE KEY UPDATE` option while inserting new data